### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL scheme check

### DIFF
--- a/pkg/mirror/manager.go
+++ b/pkg/mirror/manager.go
@@ -264,8 +264,8 @@ func (m *Manager) parseDirectoryListing(resp *http.Response, baseURL string) ([]
 			// Skip certain links (security: prevent various types of malicious links)
 			if strings.HasPrefix(link, "http://") || strings.HasPrefix(link, "https://") ||
 				strings.HasPrefix(link, "mailto:") || strings.HasPrefix(link, "ftp://") ||
-				strings.HasPrefix(link, "javascript:") || strings.HasPrefix(link, "#") ||
-				link == "/" || link == "./" {
+				strings.HasPrefix(link, "javascript:") || strings.HasPrefix(link, "data:") || strings.HasPrefix(link, "vbscript:") ||
+				strings.HasPrefix(link, "#") || link == "/" || link == "./" {
 				continue
 			}
 


### PR DESCRIPTION
Potential fix for [https://github.com/JHOFER-Cloud/http-mirror/security/code-scanning/3](https://github.com/JHOFER-Cloud/http-mirror/security/code-scanning/3)

To fully address the risk, the filter on line 267 must be expanded to also skip links which begin with `data:` and `vbscript:`. The best way to do this is to add two more conditions to the `if` statement in line 267, similarly to how `javascript:` is checked. This can be done by adding `strings.HasPrefix(link, "data:")` and `strings.HasPrefix(link, "vbscript:")` within the same conditional. No additional imports or external libraries are needed, as the necessary string checks are already performed using the standard library.

Only the lines containing the `if` statement (lines 265–268) need to be modified. The logic and indentation style should remain consistent with the rest of the code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
