### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/pkg/files/handler.go
+++ b/pkg/files/handler.go
@@ -91,7 +91,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if file/directory exists
-	stat, err := os.Stat(filePath)
+	stat, err := os.Stat(cleanPath)
 	if os.IsNotExist(err) {
 		http.Error(w, "File not found", http.StatusNotFound)
 		return


### PR DESCRIPTION
Potential fix for [https://github.com/JHOFER-Cloud/http-mirror/security/code-scanning/4](https://github.com/JHOFER-Cloud/http-mirror/security/code-scanning/4)

To address the problem, all interactions with the file system must use the validated, canonical path (`cleanPath`), not the unvalidated, potentially uncontrolled `filePath`. The current code resolves the absolute path of `filePath` to `cleanPath` and checks that this is still within the root directory, but then proceeds to call `os.Stat(filePath)` instead of `os.Stat(cleanPath)`. To fix this, replace `os.Stat(filePath)` with `os.Stat(cleanPath)`. Similarly, if other file operations (such as directory opening, listing, or reading) rely on `filePath`, they should instead use `cleanPath` for consistency and security.

The only required change is to update line 94 (and any other similar uses, if any) so that file system operations happen on the normalized and validated version.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
