### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -16,6 +16,8 @@ jobs:
   test:
     name: Test Go Code
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/JHOFER-Cloud/http-mirror/security/code-scanning/1](https://github.com/JHOFER-Cloud/http-mirror/security/code-scanning/1)

To address the issue, we should add a `permissions` block to the `test` job in `.github/workflows/build_release.yml`, restricting access to only what is required. Since the job only needs to read repository content (it does not push, create releases, or interact with issues/pull-requests), the least privilege setting is `contents: read`. This will ensure the job only has read-only permission to the repository contents, reducing risk. You need to edit the region of the file starting at line 17, adding the `permissions:` block directly under the job before its steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
